### PR TITLE
Fix compilation error in branch

### DIFF
--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -86,11 +86,19 @@ def get_build_arch():
 
 def get_java_version():
     java_home = os.getenv("JAVA_HOME")
-    java_res = subprocess.Popen([java_home + "/bin/java", "-fullversion"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    out, err = java_res.communicate()
-
-    if java_res.returncode == 0:
-        return out.decode('utf-8').replace("\"", "\\\"").strip()
+    java_cmd = None
+    if java_home:
+        java_cmd = java_home + "/bin/java"
+    else:
+        # Fallback to system java on PATH
+        java_cmd = "java"
+    try:
+        java_res = subprocess.Popen([java_cmd, "-fullversion"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        out, _ = java_res.communicate()
+        if java_res.returncode == 0:
+            return out.decode('utf-8').replace("\"", "\\\"").strip()
+    except Exception:
+        pass
     return "unknown jdk"
 
 def get_fingerprint(items):


### PR DESCRIPTION
## Why I'm doing:

Fixes a compilation error in Gradle builds when the `JAVA_HOME` environment variable is not set, which caused the `gen_build_version.py` script to fail.

## What I'm doing:

Modified `build-support/gen_build_version.py` to make the `get_java_version()` function robust. It now falls back to using `java` from the system's `PATH` if `JAVA_HOME` is unset and includes error handling for the `java -fullversion` command execution.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-a9f076ed-ab88-4f7b-a345-9bc1b18137a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9f076ed-ab88-4f7b-a345-9bc1b18137a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

