### PR TITLE
Handle null starrocks home environment variable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/FileGroupProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/FileGroupProvider.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.DdlException;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.StarRocksFE;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -92,7 +93,7 @@ public class FileGroupProvider extends GroupProvider {
         if (groupFileUrl.startsWith("http://") || groupFileUrl.startsWith("https://")) {
             return new URL(groupFileUrl).openStream();
         } else {
-            String filePath = System.getenv("STARROCKS_HOME") + "/conf/" + groupFileUrl;
+            String filePath = StarRocksFE.STARROCKS_HOME_DIR + "/conf/" + groupFileUrl;
             return new FileInputStream(filePath);
         }
     }


### PR DESCRIPTION
## Why I'm doing:
To fix a bug where the `getPath` method in `FileGroupProvider.java` could construct invalid file paths (e.g., "null/conf/filename") if the `STARROCKS_HOME` environment variable was not set, leading to `FileInputStream` failures. This was due to directly using `System.getenv("STARROCKS_HOME")`, which returns `null` when the variable is undefined.

## What I'm doing:
Replaced `System.getenv("STARROCKS_HOME")` with `StarRocksFE.STARROCKS_HOME_DIR` in `FileGroupProvider.java`. This ensures consistent and correct handling of the `STARROCKS_HOME` environment variable, aligning with existing patterns in the codebase. Also added the necessary import for `StarRocksFE`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-af5e8c08-4261-479f-9c51-a5d4ac4a525f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af5e8c08-4261-479f-9c51-a5d4ac4a525f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

